### PR TITLE
Fixed require to be case-sensitive

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -1,5 +1,5 @@
 love.event.quit()
-local nfs = require("nfs.nativefs")
+local nfs = require("NFS.nativefs")
 local lfs = love.filesystem
 local args = require("args")
 


### PR DESCRIPTION
On Linux, the `require("nfs.nativefs")` errors coz the directory is `NFS` and not `nfs`

On Windows this would not be a problem iirc since on windows paths are not case-sensitive or something.